### PR TITLE
thread name for the Executor

### DIFF
--- a/vst/src/main/java/com/arangodb/vst/internal/VstConnection.java
+++ b/vst/src/main/java/com/arangodb/vst/internal/VstConnection.java
@@ -171,7 +171,15 @@ public abstract class VstConnection<T> implements Connection {
         }
         sendProtocolHeader();
 
-        executor = Executors.newSingleThreadExecutor();
+        Executors.newSingleThreadExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(@NotNull Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("Arangodb-VstConnection");
+                return thread;
+            }
+        });
+
         executor.submit((Callable<Void>) () -> {
             LOGGER.debug("[" + connectionName + "]: Start Callable");
 

--- a/vst/src/main/java/com/arangodb/vst/internal/VstConnection.java
+++ b/vst/src/main/java/com/arangodb/vst/internal/VstConnection.java
@@ -171,7 +171,7 @@ public abstract class VstConnection<T> implements Connection {
         }
         sendProtocolHeader();
 
-        Executors.newSingleThreadExecutor(new ThreadFactory() {
+        executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
             @Override
             public Thread newThread(@NotNull Runnable r) {
                 Thread thread = new Thread(r);


### PR DESCRIPTION
libs should always set thread names, otherwise people debugging large apps are faced with loads of threads and have no idea where they came from or what they are doing